### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/push-docker.yml
+++ b/.github/workflows/push-docker.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Publish Docker
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: registry.cn-hangzhou.aliyuncs.com/dreamer2q/typecho-nginx
           registry: registry.cn-hangzhou.aliyuncs.com
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Publish Docker
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: registry.cn-hangzhou.aliyuncs.com/dreamer2q/typecho-lighttpd
           registry: registry.cn-hangzhou.aliyuncs.com


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore